### PR TITLE
Add annotation interactions

### DIFF
--- a/app/api/annotations/[id]/route.ts
+++ b/app/api/annotations/[id]/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+
+export async function GET(_: NextRequest, { params }: { params: { id: string } }) {
+  const annotation = await prisma.annotation.findUnique({ where: { id: params.id } })
+  if (!annotation) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  return NextResponse.json(annotation)
+}
+
+export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+  const data = await req.json()
+  const annotation = await prisma.annotation.update({ where: { id: params.id }, data })
+  return NextResponse.json(annotation)
+}
+
+export async function DELETE(_: NextRequest, { params }: { params: { id: string } }) {
+  await prisma.annotation.delete({ where: { id: params.id } })
+  return NextResponse.json({})
+}

--- a/app/api/annotations/route.ts
+++ b/app/api/annotations/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+
+export async function GET(req: NextRequest) {
+  const documentId = req.nextUrl.searchParams.get('documentId')
+  const annotations = await prisma.annotation.findMany({
+    where: documentId ? { documentId } : undefined,
+    orderBy: { createdAt: 'asc' },
+  })
+  return NextResponse.json(annotations)
+}
+
+export async function POST(req: NextRequest) {
+  const data = await req.json()
+  const annotation = await prisma.annotation.create({ data })
+  return NextResponse.json(annotation)
+}

--- a/app/pdf-hypothesis/page.tsx
+++ b/app/pdf-hypothesis/page.tsx
@@ -1,0 +1,18 @@
+'use client'
+import PdfViewer from '@/components/PdfViewer'
+import AnnotationSidebar from '@/components/AnnotationSidebar'
+import { AnnotationProvider } from '@/context/AnnotationContext'
+
+export default function Page() {
+  const url = '/sample-pdfs/contract.pdf'
+  return (
+    <AnnotationProvider documentId={url}>
+      <div className="flex h-screen">
+        <div className="flex-1 relative">
+          <PdfViewer pdfUrl={url} />
+        </div>
+        <AnnotationSidebar />
+      </div>
+    </AnnotationProvider>
+  )
+}

--- a/components/AnnotationAdder.tsx
+++ b/components/AnnotationAdder.tsx
@@ -1,0 +1,53 @@
+'use client'
+import { Rect } from './hooks/useAdderOnPage'
+import { useContext } from 'react'
+import { AnnotationContext, NewAnnotation } from '@/context/AnnotationContext'
+
+export default function AnnotationAdder({ rect, pageIndex }: { rect: Rect; pageIndex: number }) {
+  const { addHighlight, addAnnotation } = useContext(AnnotationContext)
+
+  const getInfo = (): NewAnnotation | null => {
+    const sel = window.getSelection()
+    if (!sel || sel.isCollapsed) return null
+    const range = sel.getRangeAt(0)
+    const page = document.querySelectorAll('.pdf-page')[pageIndex] as HTMLElement
+    if (!page || !page.contains(range.commonAncestorContainer)) return null
+    const bounds = page.getBoundingClientRect()
+    const rects = Array.from(range.getClientRects()).map(r => ({
+      top: (r.top - bounds.top) / bounds.height,
+      left: (r.left - bounds.left) / bounds.width,
+      width: r.width / bounds.width,
+      height: r.height / bounds.height,
+    }))
+    const selectedText = sel.toString()
+    return { documentId: window.location.pathname, pageNumber: pageIndex, rects, selectedText }
+  }
+
+  const handleHighlight = async () => {
+    const info = getInfo()
+    if (!info) return
+    await addHighlight(info)
+    selClear()
+  }
+
+  const handleAnnotate = async () => {
+    const info = getInfo()
+    if (!info) return
+    await addAnnotation(info)
+    selClear()
+  }
+
+  const selClear = () => {
+    const sel = window.getSelection()
+    if (sel) sel.removeAllRanges()
+  }
+  return (
+    <div
+      style={{ top: rect.top + rect.height, left: rect.left + rect.width / 2 }}
+      className="absolute flex space-x-1 text-xs bg-gray-800 text-white px-2 py-1 rounded"
+    >
+      <button onClick={handleHighlight}>Highlight</button>
+      <button onClick={handleAnnotate}>Annotate</button>
+    </div>
+  )
+}

--- a/components/AnnotationOverlay.tsx
+++ b/components/AnnotationOverlay.tsx
@@ -1,0 +1,24 @@
+'use client'
+import { useContext } from 'react'
+import { BoundingBox } from '@allenai/pdf-components'
+import { AnnotationContext } from '@/context/AnnotationContext'
+
+export default function AnnotationOverlay({ pageIndex }: { pageIndex: number }) {
+  const { annotations, setActiveAnnotationId, activeAnnotationId } = useContext(AnnotationContext)
+  const pageAnnots = annotations.filter(a => a.pageNumber === pageIndex)
+  return (
+    <>
+      {pageAnnots.map(a =>
+        a.rects.map((r: any, i: number) => (
+          <BoundingBox
+            key={a.id + i}
+            page={pageIndex}
+            {...r}
+            className={`bg-yellow-300 bg-opacity-50 ${activeAnnotationId === a.id ? 'ring-2 ring-yellow-400' : ''}`}
+            onClick={() => setActiveAnnotationId(a.id)}
+          />
+        ))
+      )}
+    </>
+  )
+}

--- a/components/AnnotationSidebar/Editor.tsx
+++ b/components/AnnotationSidebar/Editor.tsx
@@ -1,0 +1,23 @@
+'use client'
+import { useState, useContext } from 'react'
+import { Annotation, AnnotationContext } from '@/context/AnnotationContext'
+
+export default function Editor({ draft }: { draft: Annotation }) {
+  const [note, setNote] = useState(draft.note || '')
+  const { updateAnnotation } = useContext(AnnotationContext)
+  return (
+    <div className="mt-1">
+      <textarea
+        value={note}
+        onChange={e => setNote(e.target.value)}
+        className="w-full border rounded p-1 text-sm"
+      />
+      <button
+        className="mt-1 text-xs"
+        onClick={() => updateAnnotation(draft.id, { note, editing: false })}
+      >
+        Post
+      </button>
+    </div>
+  )
+}

--- a/components/AnnotationSidebar/Item.tsx
+++ b/components/AnnotationSidebar/Item.tsx
@@ -1,0 +1,20 @@
+'use client'
+import { useContext } from 'react'
+import { AnnotationContext, Annotation } from '@/context/AnnotationContext'
+import Editor from './Editor'
+
+export default function Item({ ann, depth = 0 }: { ann: Annotation; depth?: number }) {
+  const { activeAnnotationId, setActiveAnnotationId } = useContext(AnnotationContext)
+  const active = activeAnnotationId === ann.id
+  return (
+    <div
+      className={`p-3 border-b ${active ? 'bg-yellow-100' : ''}`}
+      onMouseEnter={() => setActiveAnnotationId(ann.id)}
+    >
+      {ann.selectedText && <p className="italic text-gray-600">“{ann.selectedText}”</p>}
+      {ann.editing ? <Editor draft={ann} /> : <p className="mt-1">{ann.note}</p>}
+      <div className="text-xs text-gray-500">{ann.tags?.join(', ')}</div>
+      {ann.replies && ann.replies.map(r => <Item key={r.id} ann={r} depth={depth + 1} />)}
+    </div>
+  )
+}

--- a/components/AnnotationSidebar/index.tsx
+++ b/components/AnnotationSidebar/index.tsx
@@ -1,0 +1,18 @@
+'use client'
+import { useContext } from 'react'
+import { AnnotationContext } from '@/context/AnnotationContext'
+import Item from './Item'
+
+export default function AnnotationSidebar() {
+  const { annotations } = useContext(AnnotationContext)
+  return (
+    <aside className="fixed right-0 top-0 w-80 h-full bg-gray-50 border-l flex flex-col">
+      <div className="bg-gray-100 p-2 font-medium">Annotations</div>
+      <div className="flex-1 overflow-y-auto">
+        {annotations.map(a => (
+          <Item key={a.id} ann={a} />
+        ))}
+      </div>
+    </aside>
+  )
+}

--- a/components/PageView.tsx
+++ b/components/PageView.tsx
@@ -1,0 +1,20 @@
+'use client'
+import { FC } from 'react'
+import { PageWrapper, Overlay } from '@allenai/pdf-components'
+import AnnotationOverlay from './AnnotationOverlay'
+import AnnotationAdder from './AnnotationAdder'
+import { useAdderOnPage } from '@/hooks/useAdderOnPage'
+
+const PageView: FC<{ pageIndex: number }> = ({ pageIndex }) => {
+  const { showAdder, rect } = useAdderOnPage(pageIndex)
+  return (
+    <PageWrapper pageIndex={pageIndex} className="pdf-page">
+      <Overlay>
+        <AnnotationOverlay pageIndex={pageIndex} />
+        {showAdder && rect && <AnnotationAdder rect={rect} pageIndex={pageIndex} />}
+      </Overlay>
+    </PageWrapper>
+  )
+}
+
+export default PageView

--- a/components/PdfViewer.tsx
+++ b/components/PdfViewer.tsx
@@ -1,0 +1,15 @@
+'use client'
+import { DocumentWrapper, DocumentContext } from '@allenai/pdf-components'
+import { useContext } from 'react'
+import PageView from './PageView'
+
+export default function PdfViewer({ pdfUrl }: { pdfUrl: string }) {
+  const { numPages } = useContext(DocumentContext)
+  return (
+    <DocumentWrapper file={pdfUrl}>
+      {Array.from({ length: numPages }, (_, i) => (
+        <PageView key={i} pageIndex={i} />
+      ))}
+    </DocumentWrapper>
+  )
+}

--- a/components/hooks/useAdderOnPage.tsx
+++ b/components/hooks/useAdderOnPage.tsx
@@ -1,0 +1,48 @@
+'use client'
+import { useState, useEffect } from 'react'
+
+export interface Rect {
+  top: number
+  left: number
+  width: number
+  height: number
+}
+
+export function useAdderOnPage(pageIndex: number) {
+  const [rect, setRect] = useState<Rect | null>(null)
+  const [showAdder, setShowAdder] = useState(false)
+
+  useEffect(() => {
+    const handler = () => {
+      const sel = document.getSelection()
+      if (!sel || sel.isCollapsed) {
+        setShowAdder(false)
+        return
+      }
+      const range = sel.getRangeAt(0)
+      const rects = range.getClientRects()
+      if (rects.length === 0) {
+        setShowAdder(false)
+        return
+      }
+      const last = rects[rects.length - 1]
+      const page = document.querySelectorAll('.pdf-page')[pageIndex] as HTMLElement
+      if (!page || !page.contains(range.commonAncestorContainer)) {
+        setShowAdder(false)
+        return
+      }
+      const bounds = page.getBoundingClientRect()
+      setRect({
+        top: last.top - bounds.top,
+        left: last.left - bounds.left,
+        width: last.width,
+        height: last.height,
+      })
+      setShowAdder(true)
+    }
+    document.addEventListener('selectionchange', handler)
+    return () => document.removeEventListener('selectionchange', handler)
+  }, [pageIndex])
+
+  return { showAdder, rect }
+}

--- a/context/AnnotationContext.tsx
+++ b/context/AnnotationContext.tsx
@@ -1,0 +1,93 @@
+'use client'
+import { createContext, useState, ReactNode, useEffect } from 'react'
+
+export interface Annotation {
+  id: string
+  documentId: string
+  pageNumber: number
+  rects: any[]
+  selectedText: string
+  note: string
+  tags: string[]
+  parentId?: string | null
+  replies?: Annotation[]
+  editing?: boolean
+}
+
+interface Ctx {
+  annotations: Annotation[]
+  activeAnnotationId: string | null
+  setActiveAnnotationId: (id: string | null) => void
+  addHighlight: (info: NewAnnotation) => Promise<Annotation | void>
+  addAnnotation: (info: NewAnnotation) => Promise<Annotation | void>
+  updateAnnotation: (id: string, data: Partial<Annotation>) => Promise<void>
+}
+
+export const AnnotationContext = createContext<Ctx>({
+  annotations: [],
+  activeAnnotationId: null,
+  setActiveAnnotationId: () => {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  addHighlight: async () => undefined,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  addAnnotation: async () => undefined,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  updateAnnotation: async () => {},
+})
+
+export interface NewAnnotation {
+  documentId: string
+  pageNumber: number
+  rects: any[]
+  selectedText: string
+  note?: string
+  tags?: string[]
+  parentId?: string | null
+}
+
+export function AnnotationProvider({ documentId, children }: { documentId: string; children: ReactNode }) {
+  const [annotations, setAnnotations] = useState<Annotation[]>([])
+  const [activeAnnotationId, setActiveAnnotationId] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetch(`/api/annotations?documentId=${encodeURIComponent(documentId)}`)
+      .then(res => res.json())
+      .then(setAnnotations)
+      .catch(() => {})
+  }, [documentId])
+
+  const addHighlight = async (info: NewAnnotation) => {
+    const res = await fetch('/api/annotations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...info, note: info.note ?? '', tags: info.tags ?? [] }),
+    })
+    const ann = await res.json()
+    setAnnotations(prev => [...prev, ann])
+    return ann
+  }
+  const addAnnotation = async (info: NewAnnotation) => {
+    const ann = await addHighlight({ ...info, note: info.note ?? '' })
+    if (ann) {
+      setAnnotations(prev =>
+        prev.map(a => (a.id === ann.id ? { ...a, editing: true } : a))
+      )
+    }
+  }
+
+  const updateAnnotation = async (id: string, data: Partial<Annotation>) => {
+    const res = await fetch(`/api/annotations/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    const ann = await res.json()
+    setAnnotations(prev => prev.map(a => (a.id === id ? ann : a)))
+  }
+
+  return (
+    <AnnotationContext.Provider value={{ annotations, activeAnnotationId, setActiveAnnotationId, addHighlight, addAnnotation, updateAnnotation }}>
+      {children}
+    </AnnotationContext.Provider>
+  )
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient | undefined }
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient()
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
+
+export default prisma

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "tailwind-merge": "^3.0.2",
     "tw-animate-css": "^1.2.5",
     "usehooks-ts": "^3.1.1"
+    ,"@prisma/client": "^5.15.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -59,6 +60,7 @@
     "style-loader": "^4.0.0",
     "tailwindcss": "^4",
     "tailwindcss-animate": "^1.0.7",
-    "typescript": "^5"
+    "typescript": "^5",
+    "prisma": "^5.15.0"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,21 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model Annotation {
+  id          String   @id @default(cuid())
+  documentId  String
+  pageNumber  Int
+  rects       Json
+  selectedText String
+  note        String
+  tags        Json
+  parentId    String?  @default(null)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}


### PR DESCRIPTION
## Summary
- fetch and store annotations for pdf pages
- save selected text as highlights or editable annotations
- allow notes to be posted from the sidebar editor

## Testing
- `npx next lint` *(fails: EHOSTUNREACH registry.npmjs.org)*