### PR TITLE
Remove temp types symlink

### DIFF
--- a/temp-types.d.ts
+++ b/temp-types.d.ts
@@ -1,1 +1,0 @@
-/Users/newmacbookpro/Developmet workspace/annotator/my-app/node_modules/@allenai/pdf-components/dist/index.d.ts

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     ],
     "paths": {
       "@/*": ["./*"],
-      "components/*": ["components/*"]
+      "components/*": ["components/*"],
+      "@allenai/pdf-components": ["node_modules/@allenai/pdf-components/dist/index.d.ts"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
- remove `temp-types.d.ts` which was a broken symlink
- configure `tsconfig.json` to resolve `@allenai/pdf-components` directly from `node_modules`

## Testing
- `npm run lint` *(fails: `next` not found)*