### PR TITLE
Integrate annotation provider with API

### DIFF
--- a/app/pdf-hypothesis/page.tsx
+++ b/app/pdf-hypothesis/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 import PdfViewer from '@/components/PdfViewer'
-import AnnotationSidebar from '@/components/AnnotationSidebar'
-import { AnnotationProvider } from '@/context/AnnotationContext'
+import { AnnotationSidebar as ProfessionalAnnotationSidebar } from '@/components/context_panel/annotations/ProfessionalAnnotationSidebar'
+import { AnnotationProvider } from '@/components/context_panel/annotations/AnnotationProvider'
 
 export default function Page() {
   const url = '/sample-pdfs/contract.pdf'
@@ -11,7 +11,7 @@ export default function Page() {
         <div className="flex-1 relative">
           <PdfViewer pdfUrl={url} />
         </div>
-        <AnnotationSidebar />
+        <ProfessionalAnnotationSidebar />
       </div>
     </AnnotationProvider>
   )

--- a/components/context_panel/annotations/AnnotationActionsMenu.tsx
+++ b/components/context_panel/annotations/AnnotationActionsMenu.tsx
@@ -14,11 +14,11 @@ interface Props {
 }
 
 export default function AnnotationActionsMenu({ annotation }: Props) {
-  const { dispatch } = useAnnotations();
+  const { deleteAnnotation } = useAnnotations();
   const [openEdit, setOpenEdit] = React.useState(false);
 
   const handleDelete = () => {
-    dispatch({ type: 'DELETE_ANNOTATION', id: annotation.id });
+    deleteAnnotation(annotation.id);
   };
 
   return (

--- a/components/context_panel/annotations/AnnotationEditDialog.tsx
+++ b/components/context_panel/annotations/AnnotationEditDialog.tsx
@@ -12,16 +12,12 @@ interface Props {
 }
 
 export default function AnnotationEditDialog({ annotation, onClose }: Props) {
-  const { dispatch } = useAnnotations();
+  const { updateAnnotation } = useAnnotations();
   const [category, setCategory] = useState(annotation.category);
   const [comment, setComment] = useState(annotation.comment || '');
 
   const handleSave = () => {
-    dispatch({
-      type: 'UPDATE_ANNOTATION',
-      id: annotation.id,
-      updates: { category, comment },
-    });
+    updateAnnotation(annotation.id, { category, comment });
     onClose();
   };
 

--- a/components/context_panel/annotations/SkimmingHighlightsPanel.tsx
+++ b/components/context_panel/annotations/SkimmingHighlightsPanel.tsx
@@ -18,7 +18,7 @@ interface SkimmingHighlightProps {
 }
 
 export default function SkimmingHighlightsPanel() {
-  const { state, dispatch } = useAnnotations();
+  const { state, addAnnotation, dispatch } = useAnnotations();
   const [showSettings, setShowSettings] = useState(false);
   
   // Get highlights suitable for skimming from our annotations
@@ -110,7 +110,7 @@ export default function SkimmingHighlightsPanel() {
     
     // Add the highlights to the state
     mockHighlights.forEach(highlight => {
-      dispatch({ type: 'ADD_ANNOTATION', annotation: highlight });
+      addAnnotation(highlight);
     });
   };
   


### PR DESCRIPTION
## Summary
- swap pdf-hypothesis page to use `ProfessionalAnnotationSidebar`
- replace deprecated context with new `AnnotationProvider`
- implement persistence functions in provider
- call provider functions from annotation dialogs and menus
- wire skimming highlights to use the new add API

## Testing
- `npm run lint` *(fails: `next` not found)*