### PR TITLE
Add group filter for annotations

### DIFF
--- a/components/context_panel/annotations/ProfessionalAnnotationSidebar.tsx
+++ b/components/context_panel/annotations/ProfessionalAnnotationSidebar.tsx
@@ -41,6 +41,7 @@ export interface Annotation {
   text: string;
   excerpt: string;
   page: number;
+  groupId?: string;
   createdAt: Date;
   author: {
     name: string;
@@ -233,21 +234,28 @@ export function AnnotationSidebar({
   const [searchQuery, setSearchQuery] = React.useState("");
   const [selectedTypes, setSelectedTypes] = React.useState<Annotation["type"][]>([]);
   const [sortBy, setSortBy] = React.useState<"newest" | "oldest" | "type">("newest");
+  const [selectedGroup, setSelectedGroup] = React.useState<string>("all");
+  const groups = React.useMemo(
+    () => Array.from(new Set(annotations.map(a => a.groupId).filter(Boolean))),
+    [annotations]
+  );
 
   // Filter annotations based on search, type, and current page
   const filteredAnnotations = React.useMemo(() => {
     return annotations.filter(annotation => {
       // Filter by search query
-      const matchesSearch = searchQuery === "" || 
+      const matchesSearch = searchQuery === "" ||
         annotation.text.toLowerCase().includes(searchQuery.toLowerCase()) ||
         annotation.excerpt.toLowerCase().includes(searchQuery.toLowerCase());
-      
+
       // Filter by selected types
       const matchesType = selectedTypes.length === 0 || selectedTypes.includes(annotation.type);
-      
-      return matchesSearch && matchesType;
+
+      // Filter by selected group
+      const matchesGroup = selectedGroup === "all" || annotation.groupId === selectedGroup;
+      return matchesSearch && matchesType && matchesGroup;
     });
-  }, [annotations, searchQuery, selectedTypes]);
+  }, [annotations, searchQuery, selectedTypes, selectedGroup]);
 
   // Get annotations for current page
   const currentPageAnnotations = React.useMemo(() => {
@@ -315,11 +323,28 @@ export function AnnotationSidebar({
   const clearFilters = () => {
     setSelectedTypes([]);
     setSearchQuery("");
+    setSelectedGroup("all");
   };
 
   return (
     <div className={cn("flex h-full flex-col", className)}>
       <div className="border-b p-4">
+        {groups.length > 0 && (
+          <div>
+            <select
+              className="w-full rounded-md border bg-background px-2 py-1 text-sm"
+              value={selectedGroup}
+              onChange={(e) => setSelectedGroup(e.target.value)}
+            >
+              <option value="all">All Groups</option>
+              {groups.map((g) => (
+                <option key={g} value={g}>
+                  {g}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
         <div className="mt-2">
           <div className="relative">
             <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
@@ -358,7 +383,7 @@ export function AnnotationSidebar({
               <span className="ml-1 capitalize">{type}</span>
             </Badge>
           ))}
-          {(selectedTypes.length > 0 || searchQuery) && (
+          {(selectedTypes.length > 0 || searchQuery || selectedGroup !== "all") && (
             <Button
               variant="ghost"
               size="sm"
@@ -407,7 +432,7 @@ export function AnnotationSidebar({
               ) : (
                 <div className="flex h-32 flex-col items-center justify-center text-center text-muted-foreground">
                   <p>No annotations found</p>
-                  {(selectedTypes.length > 0 || searchQuery) && (
+                  {(selectedTypes.length > 0 || searchQuery || selectedGroup !== "all") && (
                     <Button
                       variant="link"
                       size="sm"
@@ -491,6 +516,7 @@ export const mockAnnotations: Annotation[] = [
     text: "Non-Compete Clause",
     excerpt: "The Contractor agrees not to engage in any activity that competes with the Company for a period of two years after termination.",
     page: 2,
+    groupId: "group-a",
     createdAt: new Date("2023-10-15T14:30:00"),
     author: {
       name: "Jane Smith",
@@ -526,6 +552,7 @@ export const mockAnnotations: Annotation[] = [
     text: "Liability Limitation",
     excerpt: "Company's liability shall not exceed the total amount paid by Client in the 12 months preceding any claim.",
     page: 3,
+    groupId: "group-a",
     createdAt: new Date("2023-10-14T11:20:00"),
     author: {
       name: "Michael Chen"
@@ -547,6 +574,7 @@ export const mockAnnotations: Annotation[] = [
     text: "Intellectual Property Definition",
     excerpt: "\"Intellectual Property\" means all patents, trademarks, copyrights, trade secrets, and other proprietary rights.",
     page: 1,
+    groupId: "group-b",
     createdAt: new Date("2023-10-13T09:15:00"),
     author: {
       name: "Sarah Williams"
@@ -559,6 +587,7 @@ export const mockAnnotations: Annotation[] = [
     text: "Reference to Master Agreement",
     excerpt: "This Statement of Work is governed by the terms of the Master Services Agreement dated January 1, 2023.",
     page: 2,
+    groupId: "group-b",
     createdAt: new Date("2023-10-12T16:40:00"),
     author: {
       name: "David Lee"


### PR DESCRIPTION
## Summary
- support `groupId` on annotations
- allow selecting annotation group in ProfessionalAnnotationSidebar
- filter results by the selected group

## Testing
- `npm run lint` *(fails: next not found)*