### PR TITLE
Add tag support for annotations

### DIFF
--- a/components/context_panel/annotations/AnnotationProvider.tsx
+++ b/components/context_panel/annotations/AnnotationProvider.tsx
@@ -161,9 +161,11 @@ export function AnnotationProvider({ children, documentId }: AnnotationProviderP
       .then(res => res.json())
       .then(data => {
         // Transform the data if needed and validate it
-        const validAnnotations = Array.isArray(data) ? data.filter(ann => 
-          ann && typeof ann === 'object' && ann.id && ann.type
-        ) : [];
+        const validAnnotations = Array.isArray(data)
+          ? data
+              .filter(ann => ann && typeof ann === 'object' && ann.id && ann.type)
+              .map(ann => ({ ...ann, tags: ann.tags ?? [] }))
+          : [];
         dispatch({ type: 'SET_ANNOTATIONS', annotations: validAnnotations });
       })
       .catch((err) => {
@@ -174,20 +176,22 @@ export function AnnotationProvider({ children, documentId }: AnnotationProviderP
   }, [documentId]);
 
   const addAnnotation = async (annotation: Annotation) => {
+    const payload = { ...annotation, tags: annotation.tags ?? [] };
     const res = await fetch('/api/annotations', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(annotation)
+      body: JSON.stringify(payload)
     });
     const saved = await res.json();
     dispatch({ type: 'ADD_ANNOTATION', annotation: saved });
   };
 
   const updateAnnotation = async (id: string, data: Partial<Annotation>) => {
+    const payload = { ...data };
     const res = await fetch(`/api/annotations/${id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data)
+      body: JSON.stringify(payload)
     });
     const updated = await res.json();
     dispatch({ type: 'UPDATE_ANNOTATION', id, data: updated });

--- a/components/context_panel/annotations/ProfessionalAnnotationSidebar.tsx
+++ b/components/context_panel/annotations/ProfessionalAnnotationSidebar.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Input } from "@/components/ui/input";
+import { useAnnotations } from "./AnnotationProvider";
 import { 
   BookText, 
   AlertTriangle, 
@@ -47,6 +48,7 @@ export interface Annotation {
     avatar?: string;
   };
   comments: Comment[];
+  tags: string[];
   citation?: {
     source: string;
     page?: number;
@@ -110,17 +112,32 @@ const AnnotationTypeBadge = ({ type }: { type: Annotation["type"] }) => (
   </Badge>
 );
 
-const AnnotationCard = ({ 
-  annotation, 
-  expanded = false, 
-  onClick 
-}: { 
-  annotation: Annotation; 
+const AnnotationCard = ({
+  annotation,
+  expanded = false,
+  onClick
+}: {
+  annotation: Annotation;
   expanded?: boolean;
   onClick?: () => void;
 }) => {
   const [isExpanded, setIsExpanded] = React.useState(expanded);
   const [showComments, setShowComments] = React.useState(false);
+  const [newTag, setNewTag] = React.useState("");
+  const { updateAnnotation } = useAnnotations();
+
+  const handleAddTag = () => {
+    const tag = newTag.trim();
+    if (!tag) return;
+    const newTags = Array.from(new Set([...(annotation.tags || []), tag]));
+    updateAnnotation(annotation.id, { tags: newTags });
+    setNewTag("");
+  };
+
+  const handleRemoveTag = (tag: string) => {
+    const newTags = (annotation.tags || []).filter(t => t !== tag);
+    updateAnnotation(annotation.id, { tags: newTags });
+  };
 
   const toggleExpand = () => {
     setIsExpanded(!isExpanded);
@@ -145,6 +162,38 @@ const AnnotationCard = ({
 
         <div className="mt-2">
           <p className="text-sm font-medium">{annotation.text}</p>
+
+          {(annotation.tags && annotation.tags.length > 0) || isExpanded ? (
+            <div className="mt-1 flex flex-wrap gap-1">
+              {annotation.tags.map(tag => (
+                <Badge key={tag} variant="secondary" className="pr-1">
+                  {tag}
+                  {isExpanded && (
+                    <button
+                      className="ml-1 text-muted-foreground hover:text-foreground"
+                      onClick={() => handleRemoveTag(tag)}
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  )}
+                </Badge>
+              ))}
+              {isExpanded && (
+                <Input
+                  value={newTag}
+                  onChange={e => setNewTag(e.target.value)}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      handleAddTag();
+                    }
+                  }}
+                  placeholder="Add tag"
+                  className="h-6 w-20 px-1 py-0 text-xs"
+                />
+              )}
+            </div>
+          ) : null}
           
           {isExpanded && (
             <div className="mt-2">
@@ -232,7 +281,14 @@ export function AnnotationSidebar({
 }: AnnotationSidebarProps) {
   const [searchQuery, setSearchQuery] = React.useState("");
   const [selectedTypes, setSelectedTypes] = React.useState<Annotation["type"][]>([]);
+  const [selectedTags, setSelectedTags] = React.useState<string[]>([]);
   const [sortBy, setSortBy] = React.useState<"newest" | "oldest" | "type">("newest");
+
+  const allTags = React.useMemo(() => {
+    const tags = new Set<string>();
+    annotations.forEach(a => a.tags?.forEach(t => tags.add(t)));
+    return Array.from(tags);
+  }, [annotations]);
 
   // Filter annotations based on search, type, and current page
   const filteredAnnotations = React.useMemo(() => {
@@ -244,10 +300,14 @@ export function AnnotationSidebar({
       
       // Filter by selected types
       const matchesType = selectedTypes.length === 0 || selectedTypes.includes(annotation.type);
-      
-      return matchesSearch && matchesType;
+
+      const matchesTags =
+        selectedTags.length === 0 ||
+        (annotation.tags && annotation.tags.some(t => selectedTags.includes(t)));
+
+      return matchesSearch && matchesType && matchesTags;
     });
-  }, [annotations, searchQuery, selectedTypes]);
+  }, [annotations, searchQuery, selectedTypes, selectedTags]);
 
   // Get annotations for current page
   const currentPageAnnotations = React.useMemo(() => {
@@ -305,15 +365,22 @@ export function AnnotationSidebar({
   }, [filteredAnnotations]);
 
   const toggleType = (type: Annotation["type"]) => {
-    setSelectedTypes(prev => 
-      prev.includes(type) 
-        ? prev.filter(t => t !== type) 
+    setSelectedTypes(prev =>
+      prev.includes(type)
+        ? prev.filter(t => t !== type)
         : [...prev, type]
+    );
+  };
+
+  const toggleTag = (tag: string) => {
+    setSelectedTags(prev =>
+      prev.includes(tag) ? prev.filter(t => t !== tag) : [...prev, tag]
     );
   };
 
   const clearFilters = () => {
     setSelectedTypes([]);
+    setSelectedTags([]);
     setSearchQuery("");
   };
 
@@ -358,7 +425,7 @@ export function AnnotationSidebar({
               <span className="ml-1 capitalize">{type}</span>
             </Badge>
           ))}
-          {(selectedTypes.length > 0 || searchQuery) && (
+          {(selectedTypes.length > 0 || searchQuery || selectedTags.length > 0) && (
             <Button
               variant="ghost"
               size="sm"
@@ -369,6 +436,20 @@ export function AnnotationSidebar({
             </Button>
           )}
         </div>
+        {allTags.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-2">
+            {allTags.map(tag => (
+              <Badge
+                key={tag}
+                variant={selectedTags.includes(tag) ? "default" : "outline"}
+                className="cursor-pointer"
+                onClick={() => toggleTag(tag)}
+              >
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        )}
         <div className="mt-3 flex items-center justify-between">
           <div className="flex items-center gap-2">
             <Filter className="h-4 w-4 text-muted-foreground" />
@@ -407,7 +488,7 @@ export function AnnotationSidebar({
               ) : (
                 <div className="flex h-32 flex-col items-center justify-center text-center text-muted-foreground">
                   <p>No annotations found</p>
-                  {(selectedTypes.length > 0 || searchQuery) && (
+                  {(selectedTypes.length > 0 || searchQuery || selectedTags.length > 0) && (
                     <Button
                       variant="link"
                       size="sm"
@@ -514,6 +595,7 @@ export const mockAnnotations: Annotation[] = [
         createdAt: new Date("2023-10-16T09:20:00")
       }
     ],
+    tags: ["contract", "non-compete"],
     citation: {
       source: "California Business and Professions Code",
       page: 16700,
@@ -539,7 +621,8 @@ export const mockAnnotations: Annotation[] = [
         },
         createdAt: new Date("2023-10-14T11:25:00")
       }
-    ]
+    ],
+    tags: ["liability", "limit"]
   },
   {
     id: "3",
@@ -551,7 +634,8 @@ export const mockAnnotations: Annotation[] = [
     author: {
       name: "Sarah Williams"
     },
-    comments: []
+    comments: [],
+    tags: ["ip", "definition"]
   },
   {
     id: "4",
@@ -573,6 +657,7 @@ export const mockAnnotations: Annotation[] = [
         createdAt: new Date("2023-10-12T17:30:00")
       }
     ],
+    tags: ["reference"],
     citation: {
       source: "Master Services Agreement",
       page: 1,

--- a/components/context_panel/annotations/SkimmingHighlightsPanel.tsx
+++ b/components/context_panel/annotations/SkimmingHighlightsPanel.tsx
@@ -54,8 +54,8 @@ export default function SkimmingHighlightsPanel() {
     // Create sample highlights
     const createMockHighlight = (
       type: "clause" | "risk" | "definition" | "reference",
-      text: string, 
-      excerpt: string, 
+      text: string,
+      excerpt: string,
       page: number,
       extras?: SkimmingHighlightProps
     ): Annotation => {
@@ -67,7 +67,8 @@ export default function SkimmingHighlightsPanel() {
         page,
         createdAt: new Date(),
         author: { name: "AI Assistant" },
-        comments: []
+        comments: [],
+        tags: []
       };
     };
     


### PR DESCRIPTION
## Summary
- extend `Annotation` type with `tags` field
- default annotation tags in provider and API helpers
- support tag editing in `ProfessionalAnnotationSidebar`
- filter annotations by tags
- add sample tags to mock data

## Testing
- `npm run lint` *(fails: next not found)*