### PR TITLE
Fix duplicate useAnnotations import

### DIFF
--- a/components/context_panel/annotations/ProfessionalAnnotationSidebar.tsx
+++ b/components/context_panel/annotations/ProfessionalAnnotationSidebar.tsx
@@ -35,7 +35,6 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator
 } from "@/components/ui/dropdown-menu";
-import { useAnnotations } from "./AnnotationProvider";
 
 // Types
 export interface Annotation {


### PR DESCRIPTION
## Summary
- remove redundant `useAnnotations` import in `ProfessionalAnnotationSidebar.tsx`

## Testing
- `npm run lint` *(fails: `next` not found)*