### PR TITLE
Improve chat fallback and accessibility

### DIFF
--- a/components/context_panel/integrated_ai/AIInput.tsx
+++ b/components/context_panel/integrated_ai/AIInput.tsx
@@ -59,7 +59,7 @@ export function AIInput({
   }, [isFocused]);
 
   return (
-    <div className={cn("w-full relative", className)}>
+    <div className={cn("w-full relative", className)} aria-busy={isLoading}>
       <div className="relative" ref={containerRef}>
         <motion.div
           initial={false}
@@ -84,6 +84,7 @@ export function AIInput({
               onFocus={() => setIsFocused(true)}
               onBlur={() => setIsFocused(false)}
               placeholder={placeholderText}
+              aria-label="Chat input"
               className="min-h-[60px] max-h-[200px] resize-none p-3 pr-16 text-sm border-none focus-visible:ring-0 bg-transparent backdrop-blur-sm"
               disabled={isLoading}
               onKeyDown={handleKeyDown}

--- a/components/context_panel/integrated_ai/ChatSidebar.tsx
+++ b/components/context_panel/integrated_ai/ChatSidebar.tsx
@@ -85,9 +85,9 @@ export default function ChatSidebar({ className, onNewMessage }: ChatSidebarProp
       // Add AI response
       setMockMessages((prev) => [
         ...prev,
-        { 
-          role: "assistant", 
-          content: "This is a simulated response from the AI assistant. In production, this would be streamed from LangGraph. I can help analyze legal documents, highlight important clauses, and help with annotations.", 
+        {
+          role: "assistant",
+          content: "The AI service is currently unavailable. Please try again later.",
           isNew: true
         },
       ]);
@@ -164,8 +164,13 @@ export default function ChatSidebar({ className, onNewMessage }: ChatSidebarProp
       <CardContent className="flex-1 p-0 overflow-hidden bg-gradient-to-b from-white to-gray-50 dark:from-gray-950 dark:to-gray-900">
         <Tabs value={activeTab} className="h-full flex flex-col">
           <TabsContent value="chat" className="flex-1 flex flex-col m-0 p-0 h-full">
-            <ScrollArea className="flex-1 px-4 py-4">
-              <div className="space-y-4 mb-4">
+            <ScrollArea className="flex-1 px-4 py-4" aria-busy={isLoading}>
+              <div
+                className="space-y-4 mb-4"
+                role="log"
+                aria-live="polite"
+                aria-relevant="additions"
+              >
                 {mockMessages.map((message, i) => (
                   <div
                     key={i}


### PR DESCRIPTION
## Summary
- use generic fallback text for dev AI responses
- mark the chat log as a live region
- add aria-busy and label to chat input

## Testing
- `npm run lint` *(fails: `next` not found)*