### PR TITLE
Add recent files history

### DIFF
--- a/components/file_explorer/ExplorerSidebar.tsx
+++ b/components/file_explorer/ExplorerSidebar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import clsx from 'clsx';
 import { Case } from '@/types/file_explorer/file-structure';
 import CaseSwitcher from '@/components/file_explorer/CaseSwitcher';
@@ -10,6 +11,7 @@ import FileTree from './FileTree';
 // Import icons from lucide-react
 import { Pin, PinOff, Folder, Search, Clock, FileText } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { useRecentFiles } from '@/lib/useRecentFiles';
 
 // Define a union type for the active panel.
 type Panel = 'explorer' | 'search' | 'history';
@@ -25,6 +27,8 @@ export default function ExplorerSidebar({ cases, isExpanded = true }: SidebarPro
   const [pinned, setPinned] = useState(true); // Default to pinned for better usability
   const [hovered, setHovered] = useState(false);
   const [activePanel, setActivePanel] = useState<Panel>('explorer');
+  const { recentFiles, clearFiles, addFile } = useRecentFiles();
+  const router = useRouter();
 
   const activeProject = cases.find((p) => p.id === activeProjectId);
 
@@ -73,11 +77,35 @@ export default function ExplorerSidebar({ cases, isExpanded = true }: SidebarPro
 
   // History Panel content (a separate panel)
   const historyPanelContent = (
-    <div className="h-full flex flex-col p-2">
-      <div className="mb-2 text-lg font-semibold">History</div>
-      <div className="flex-1 overflow-auto">
-        {/* Placeholder for recent documents */}
-        <p className="text-sm text-muted-foreground">Recent documents will be shown here.</p>
+    <div className="h-full flex flex-col p-2 space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="text-lg font-semibold">History</div>
+        {recentFiles.length > 0 && (
+          <Button variant="ghost" size="sm" onClick={clearFiles}>
+            Clear
+          </Button>
+        )}
+      </div>
+      <div className="flex-1 overflow-auto space-y-1">
+        {recentFiles.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No recent files.</p>
+        ) : (
+          recentFiles.map(file => (
+            <button
+              key={file.id}
+              className="flex w-full items-center rounded px-2 py-1 text-left hover:bg-accent"
+              onClick={() => {
+                addFile(file)
+                if (file.fileType === 'pdf') {
+                  router.push(`/workspace/viewer?file=${encodeURIComponent(file.id)}`)
+                }
+              }}
+            >
+              <FileText className="mr-2 h-4 w-4" />
+              {file.name}
+            </button>
+          ))
+        )}
       </div>
     </div>
   );

--- a/components/file_explorer/FileTree.tsx
+++ b/components/file_explorer/FileTree.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { FolderNode, FileNode } from '@/types/file_explorer/file-structure';
 import FolderNodeComponent from './FolderNode';
 import FileNodeComponent from './FileNode';
+import { useRecentFiles } from '@/lib/useRecentFiles';
 
 interface FileTreeProps {
   root: FolderNode;            // the root folder of the project
@@ -15,8 +16,10 @@ interface FileTreeProps {
 export default function FileTree({ root, searchQuery = '', onFileSelect }: FileTreeProps) {
   const router = useRouter();
   const [treeData, setTreeData] = useState(root);
-  
+  const { addFile } = useRecentFiles();
+
   const handleFileSelect = (file: FileNode) => {
+    addFile(file);
     if (file.fileType === 'pdf') {
       router.push(`/workspace/viewer?file=${encodeURIComponent(file.id)}`);
     } else {

--- a/lib/useRecentFiles.ts
+++ b/lib/useRecentFiles.ts
@@ -1,0 +1,42 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { FileNode } from '@/types/file_explorer/file-structure'
+
+const STORAGE_KEY = 'recentFiles'
+const MAX_FILES = 20
+
+export function useRecentFiles() {
+  const [recentFiles, setRecentFiles] = useState<FileNode[]>([])
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY)
+      if (stored) {
+        setRecentFiles(JSON.parse(stored))
+      }
+    } catch (err) {
+      console.error('Failed to load recent files', err)
+    }
+  }, [])
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(recentFiles))
+    } catch (err) {
+      console.error('Failed to save recent files', err)
+    }
+  }, [recentFiles])
+
+  const addFile = (file: FileNode) => {
+    setRecentFiles(prev => {
+      const filtered = prev.filter(f => f.id !== file.id)
+      const updated = [file, ...filtered]
+      return updated.slice(0, MAX_FILES)
+    })
+  }
+
+  const clearFiles = () => setRecentFiles([])
+
+  return { recentFiles, addFile, clearFiles }
+}


### PR DESCRIPTION
## Summary
- track recently opened files with a new `useRecentFiles` hook
- log file selections in `FileTree`
- display and manage recent files in `ExplorerSidebar`

## Testing
- `npx next lint` *(fails: connect EHOSTUNREACH)*