### PR TITLE
Add move and path utilities to file explorer

### DIFF
--- a/app/api/open-path/route.ts
+++ b/app/api/open-path/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { exec } from 'child_process';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+function openPath(path: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let cmd: string;
+    if (process.platform === 'darwin') {
+      cmd = `open -R "${path}"`;
+    } else if (process.platform === 'win32') {
+      cmd = `explorer /select,\"${path}\"`;
+    } else {
+      cmd = `xdg-open "${path}"`;
+    }
+    exec(cmd, err => {
+      if (err) reject(err); else resolve();
+    });
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const { path } = await request.json();
+  if (!path) {
+    return NextResponse.json({ error: 'No path provided' }, { status: 400 });
+  }
+
+  try {
+    await openPath(path);
+    return NextResponse.json({ success: true });
+  } catch (err: any) {
+    console.error('Failed to open path', err);
+    return NextResponse.json({ error: err.message || 'Failed to open path' }, { status: 500 });
+  }
+}

--- a/components/file_explorer/FileContextMenu.tsx
+++ b/components/file_explorer/FileContextMenu.tsx
@@ -11,12 +11,18 @@ import {
 interface FileContextMenuProps {
   onRename: () => void;
   onDelete: () => void;
+  onMove: () => void;
+  onCopyPath: () => void;
+  onRevealInFinder: () => void;
   children: React.ReactNode;
 }
 
 export default function FileContextMenu({
   onRename,
   onDelete,
+  onMove,
+  onCopyPath,
+  onRevealInFinder,
   children,
 }: FileContextMenuProps) {
   return (
@@ -27,7 +33,9 @@ export default function FileContextMenu({
       <ContextMenuContent>
         <ContextMenuItem onSelect={onRename}>Rename</ContextMenuItem>
         <ContextMenuItem onSelect={onDelete}>Delete</ContextMenuItem>
-        {/* Additional file-specific actions (e.g., "Download", "Move") can be added here */}
+        <ContextMenuItem onSelect={onMove}>Move</ContextMenuItem>
+        <ContextMenuItem onSelect={onCopyPath}>Copy Path</ContextMenuItem>
+        <ContextMenuItem onSelect={onRevealInFinder}>Reveal in Finder</ContextMenuItem>
       </ContextMenuContent>
     </ContextMenu>
   );

--- a/components/file_explorer/FileNode.tsx
+++ b/components/file_explorer/FileNode.tsx
@@ -11,15 +11,21 @@ interface FileNodeProps {
   onFileSelect: (file: FileNode) => void;
   onRename: (id: string, name: string) => void;
   onDelete: (id: string) => void;
+  onMove: (id: string) => void;
+  onCopyPath: (id: string) => void;
+  onRevealInFinder: (id: string) => void;
 }
 
-export default function FileNodeComponent({ file, depth, onFileSelect, onRename, onDelete }: FileNodeProps) {
+export default function FileNodeComponent({ file, depth, onFileSelect, onRename, onDelete, onMove, onCopyPath, onRevealInFinder }: FileNodeProps) {
   const [isRenaming, setIsRenaming] = useState(false);
   const [fileName, setFileName] = useState(file.name);
 
   const indentStyle = { paddingLeft: `${depth * 1.25}rem` };
 
   const handleRename = () => setIsRenaming(true);
+  const handleMove = () => onMove(file.id);
+  const handleCopyPath = () => onCopyPath(file.id);
+  const handleReveal = () => onRevealInFinder(file.id);
   const handleRenameSubmit = () => {
     setIsRenaming(false);
     if (fileName.trim() && fileName !== file.name) {
@@ -35,7 +41,13 @@ export default function FileNodeComponent({ file, depth, onFileSelect, onRename,
   };
 
   return (
-    <FileContextMenu onRename={handleRename} onDelete={handleDelete}>
+    <FileContextMenu
+      onRename={handleRename}
+      onDelete={handleDelete}
+      onMove={handleMove}
+      onCopyPath={handleCopyPath}
+      onRevealInFinder={handleReveal}
+    >
       <div
         className="flex items-center cursor-pointer hover:bg-accent hover:text-accent-foreground pr-2"
         style={indentStyle}

--- a/components/file_explorer/FolderNode.tsx
+++ b/components/file_explorer/FolderNode.tsx
@@ -14,9 +14,12 @@ interface FolderNodeProps {
   onDelete: (id: string) => void;
   onCreateFile: (parentId: string) => void;
   onCreateFolder: (parentId: string) => void;
+  onMove: (id: string) => void;
+  onCopyPath: (id: string) => void;
+  onRevealInFinder: (id: string) => void;
 }
 
-export default function FolderNodeComponent({ folder, depth, onFileSelect, onRename, onDelete, onCreateFile, onCreateFolder }: FolderNodeProps) {
+export default function FolderNodeComponent({ folder, depth, onFileSelect, onRename, onDelete, onCreateFile, onCreateFolder, onMove, onCopyPath, onRevealInFinder }: FolderNodeProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [isRenaming, setIsRenaming] = useState(false);
   const [folderName, setFolderName] = useState(folder.name);
@@ -52,6 +55,9 @@ export default function FolderNodeComponent({ folder, depth, onFileSelect, onRen
       onDelete(folder.id);
     }
   };
+  const handleMove = () => onMove(folder.id);
+  const handleCopyPath = () => onCopyPath(folder.id);
+  const handleReveal = () => onRevealInFinder(folder.id);
 
   return (
     <div>
@@ -94,6 +100,9 @@ export default function FolderNodeComponent({ folder, depth, onFileSelect, onRen
           <ContextMenuItem onSelect={handleNewFolder}>New Folder</ContextMenuItem>
           <ContextMenuItem onSelect={handleRename}>Rename</ContextMenuItem>
           <ContextMenuItem onSelect={handleDelete}>Delete</ContextMenuItem>
+          <ContextMenuItem onSelect={handleMove}>Move</ContextMenuItem>
+          <ContextMenuItem onSelect={handleCopyPath}>Copy Path</ContextMenuItem>
+          <ContextMenuItem onSelect={handleReveal}>Reveal in Finder</ContextMenuItem>
         </ContextMenuContent>
       </ContextMenu>
 
@@ -111,6 +120,9 @@ export default function FolderNodeComponent({ folder, depth, onFileSelect, onRen
                 onDelete={onDelete}
                 onCreateFile={onCreateFile}
                 onCreateFolder={onCreateFolder}
+                onMove={onMove}
+                onCopyPath={onCopyPath}
+                onRevealInFinder={onRevealInFinder}
               /> :
               <FileNodeComponent
                 key={child.id}
@@ -119,6 +131,9 @@ export default function FolderNodeComponent({ folder, depth, onFileSelect, onRen
                 onFileSelect={onFileSelect}
                 onRename={onRename}
                 onDelete={onDelete}
+                onMove={onMove}
+                onCopyPath={onCopyPath}
+                onRevealInFinder={onRevealInFinder}
               />
           )}
         </div>


### PR DESCRIPTION
## Summary
- extend file context menu with move/path actions
- offer the same context menu items for folders
- compute full paths and basic move functionality in FileTree
- add API endpoint to reveal paths via OS

## Testing
- `npm run lint` *(fails: `next` not found)*