### PR TITLE
Add persistent file tree state

### DIFF
--- a/components/file_explorer/FolderNode.tsx
+++ b/components/file_explorer/FolderNode.tsx
@@ -9,6 +9,8 @@ import { FolderIcon, ChevronRightIcon, ChevronDownIcon } from 'lucide-react'; //
 interface FolderNodeProps {
   folder: FolderNode;
   depth: number;
+  expandedFolders: Record<string, boolean>;
+  onToggleExpand: (id: string) => void;
   onFileSelect: (file: FileNode) => void;
   onRename: (id: string, name: string) => void;
   onDelete: (id: string) => void;
@@ -16,8 +18,18 @@ interface FolderNodeProps {
   onCreateFolder: (parentId: string) => void;
 }
 
-export default function FolderNodeComponent({ folder, depth, onFileSelect, onRename, onDelete, onCreateFile, onCreateFolder }: FolderNodeProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
+export default function FolderNodeComponent({
+  folder,
+  depth,
+  expandedFolders,
+  onToggleExpand,
+  onFileSelect,
+  onRename,
+  onDelete,
+  onCreateFile,
+  onCreateFolder,
+}: FolderNodeProps) {
+  const isExpanded = expandedFolders[folder.id] || false;
   const [isRenaming, setIsRenaming] = useState(false);
   const [folderName, setFolderName] = useState(folder.name);
 
@@ -25,8 +37,7 @@ export default function FolderNodeComponent({ folder, depth, onFileSelect, onRen
   const indentStyle = { paddingLeft: `${depth * 1.25}rem` }; // e.g., 1.25rem per level indent
 
   const toggleExpand = () => {
-    setIsExpanded(prev => !prev);
-    // (In a more global approach, we would notify parent to update expanded state)
+    onToggleExpand(folder.id);
   };
 
   const handleRename = () => {
@@ -106,6 +117,8 @@ export default function FolderNodeComponent({ folder, depth, onFileSelect, onRen
                 key={child.id}
                 folder={child}
                 depth={depth+1}
+                expandedFolders={expandedFolders}
+                onToggleExpand={onToggleExpand}
                 onFileSelect={onFileSelect}
                 onRename={onRename}
                 onDelete={onDelete}

--- a/lib/fileTreeStorage.ts
+++ b/lib/fileTreeStorage.ts
@@ -1,0 +1,32 @@
+export interface FileTreeState {
+  treeData: import('@/types/file_explorer/file-structure').FolderNode;
+  expanded: Record<string, boolean>;
+}
+
+const STORAGE_KEY = 'fileTreeState';
+
+export function saveFileTreeState(state: FileTreeState) {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (err) {
+    console.error('Failed to save file tree state', err);
+  }
+}
+
+export function loadFileTreeState(): FileTreeState | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as FileTreeState;
+  } catch (err) {
+    console.error('Failed to load file tree state', err);
+    return null;
+  }
+}
+
+export function clearFileTreeState() {
+  if (typeof window === 'undefined') return;
+  localStorage.removeItem(STORAGE_KEY);
+}


### PR DESCRIPTION
## Summary
- store file tree structure and expansion data in `localStorage`
- hydrate from storage before rendering FileTree
- persist changes automatically

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: missing script)*