### PR TITLE
Highlight active file in explorer

### DIFF
--- a/components/file_explorer/ExplorerSidebar.tsx
+++ b/components/file_explorer/ExplorerSidebar.tsx
@@ -25,6 +25,7 @@ export default function ExplorerSidebar({ cases, isExpanded = true }: SidebarPro
   const [pinned, setPinned] = useState(true); // Default to pinned for better usability
   const [hovered, setHovered] = useState(false);
   const [activePanel, setActivePanel] = useState<Panel>('explorer');
+  const [activeFileId, setActiveFileId] = useState('');
 
   const activeProject = cases.find((p) => p.id === activeProjectId);
 
@@ -49,8 +50,9 @@ export default function ExplorerSidebar({ cases, isExpanded = true }: SidebarPro
           <FileTree
             root={activeProject.root}
             searchQuery={searchQuery}
+            activeFileId={activeFileId}
             onFileSelect={(file) => {
-              // Handle file open (e.g. navigation or state update)
+              setActiveFileId(file.id);
             }}
           />
         )}

--- a/components/file_explorer/FileNode.tsx
+++ b/components/file_explorer/FileNode.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import clsx from 'clsx';
 import { FileNode } from '@/types/file_explorer/file-structure';
 import { FileTextIcon } from 'lucide-react';
 import FileContextMenu from './FileContextMenu';
@@ -11,9 +12,10 @@ interface FileNodeProps {
   onFileSelect: (file: FileNode) => void;
   onRename: (id: string, name: string) => void;
   onDelete: (id: string) => void;
+  activeFileId: string;
 }
 
-export default function FileNodeComponent({ file, depth, onFileSelect, onRename, onDelete }: FileNodeProps) {
+export default function FileNodeComponent({ file, depth, onFileSelect, onRename, onDelete, activeFileId }: FileNodeProps) {
   const [isRenaming, setIsRenaming] = useState(false);
   const [fileName, setFileName] = useState(file.name);
 
@@ -37,7 +39,10 @@ export default function FileNodeComponent({ file, depth, onFileSelect, onRename,
   return (
     <FileContextMenu onRename={handleRename} onDelete={handleDelete}>
       <div
-        className="flex items-center cursor-pointer hover:bg-accent hover:text-accent-foreground pr-2"
+        className={clsx(
+          'flex items-center cursor-pointer hover:bg-accent hover:text-accent-foreground pr-2',
+          activeFileId === file.id && 'bg-primary/10 text-primary'
+        )}
         style={indentStyle}
         onClick={() => onFileSelect(file)}
         draggable={true}

--- a/components/file_explorer/FileTree.tsx
+++ b/components/file_explorer/FileTree.tsx
@@ -9,18 +9,18 @@ import FileNodeComponent from './FileNode';
 interface FileTreeProps {
   root: FolderNode;            // the root folder of the project
   searchQuery?: string;
+  activeFileId: string;
   onFileSelect: (file: FileNode) => void;
 }
 
-export default function FileTree({ root, searchQuery = '', onFileSelect }: FileTreeProps) {
+export default function FileTree({ root, searchQuery = '', activeFileId, onFileSelect }: FileTreeProps) {
   const router = useRouter();
   const [treeData, setTreeData] = useState(root);
   
   const handleFileSelect = (file: FileNode) => {
+    onFileSelect(file);
     if (file.fileType === 'pdf') {
       router.push(`/workspace/viewer?file=${encodeURIComponent(file.id)}`);
-    } else {
-      onFileSelect(file);
     }
   };
 
@@ -155,6 +155,7 @@ export default function FileTree({ root, searchQuery = '', onFileSelect }: FileT
             onDelete={deleteFolder}
             onCreateFile={createFile}
             onCreateFolder={createFolder}
+            activeFileId={activeFileId}
           /> :
           <FileNodeComponent
             key={child.id}
@@ -163,6 +164,7 @@ export default function FileTree({ root, searchQuery = '', onFileSelect }: FileT
             onFileSelect={handleFileSelect}
             onRename={renameFile}
             onDelete={deleteFile}
+            activeFileId={activeFileId}
           />
       )}
     </div>

--- a/components/file_explorer/FolderNode.tsx
+++ b/components/file_explorer/FolderNode.tsx
@@ -14,9 +14,10 @@ interface FolderNodeProps {
   onDelete: (id: string) => void;
   onCreateFile: (parentId: string) => void;
   onCreateFolder: (parentId: string) => void;
+  activeFileId: string;
 }
 
-export default function FolderNodeComponent({ folder, depth, onFileSelect, onRename, onDelete, onCreateFile, onCreateFolder }: FolderNodeProps) {
+export default function FolderNodeComponent({ folder, depth, onFileSelect, onRename, onDelete, onCreateFile, onCreateFolder, activeFileId }: FolderNodeProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [isRenaming, setIsRenaming] = useState(false);
   const [folderName, setFolderName] = useState(folder.name);
@@ -111,6 +112,7 @@ export default function FolderNodeComponent({ folder, depth, onFileSelect, onRen
                 onDelete={onDelete}
                 onCreateFile={onCreateFile}
                 onCreateFolder={onCreateFolder}
+                activeFileId={activeFileId}
               /> :
               <FileNodeComponent
                 key={child.id}
@@ -119,6 +121,7 @@ export default function FolderNodeComponent({ folder, depth, onFileSelect, onRen
                 onFileSelect={onFileSelect}
                 onRename={onRename}
                 onDelete={onDelete}
+                activeFileId={activeFileId}
               />
           )}
         </div>


### PR DESCRIPTION
## Summary
- store activeFileId in `ExplorerSidebar`
- pass activeFileId into `FileTree` and nested nodes
- use the active ID to highlight the current file
- call `onFileSelect` before navigating in `FileTree`

## Testing
- `npx next lint` *(fails: connect EHOSTUNREACH)*
- `npx tsc -p tsconfig.json` *(fails: TS5090 errors)*