### PR TITLE
Fix file selection order

### DIFF
--- a/components/file_explorer/FileTree.tsx
+++ b/components/file_explorer/FileTree.tsx
@@ -39,10 +39,10 @@ export default function FileTree({ root, searchQuery = '', activeFileId, onFileS
   const { addFile } = useRecentFiles();
   const handleFileSelect = (file: FileNode) => {
     onFileSelect(file);
-    addFile(file);
     if (file.fileType === 'pdf') {
       router.push(`/workspace/viewer?file=${encodeURIComponent(file.id)}`);
     }
+    addFile(file);
   };
 
   const toggleFolderExpand = (id: string) => {


### PR DESCRIPTION
## Summary
- ensure `onFileSelect` runs before pushing to the viewer

## Testing
- `npm run lint` *(fails: `next` not found)*