### PR TITLE
Fix: Correct duplicate import in PDFViewer.tsx and clarify outline files

### DIFF
--- a/components/pdf_viewer/core/PDFViewer.tsx
+++ b/components/pdf_viewer/core/PDFViewer.tsx
@@ -39,7 +39,6 @@ import { Annotation, AnnotationType } from '../annotations/AnnotationOverlay';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Tooltip } from '@/components/ui/tooltip';
 import PDFErrorBoundary from './PDFErrorBoundary';
-import scrollService, { ScrollPosition } from '@/lib/scroll-service';
 import {
   RENDER_TYPE,
   DocumentContext,


### PR DESCRIPTION
- I removed a duplicate import of `scrollService` and `ScrollPosition` in `components/pdf_viewer/core/PDFViewer.tsx` to resolve a syntax error.
- I clarified to you that the previously mentioned "Frontend Integration Outline" and "LangGraph Multi-Doc QA Outline" were conceptual descriptions rather than standalone files, and pointed to existing documentation like `docs/api-documentation.md`.